### PR TITLE
Propose alternative stack based on a VM

### DIFF
--- a/.env
+++ b/.env
@@ -35,4 +35,6 @@ APP_SECRET=782bb8b0aeb47de4ea870794e79d82cd
 # For a PostgreSQL database, use: "postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=11&charset=utf8"
 # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
 DATABASE_URL=postgresql://resop:postgrespwd@postgres/resop?serverVersion=11&charset=utf8
+# ALTERNATIVE DATABASE_URL for the VM based stack, uncomment if you're using it
+#DATABASE_URL=pgsql://resop:postgrespwd@127.0.0.1:5432/resop?serverVersion=11&charset=utf8
 ###< doctrine/doctrine-bundle ###

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,18 @@
 /.eslintcache
 /.stylelintcache
 
+# Vagrant
+/.vagrant/
+
+# Ansible
+/ansible/*.retry
+/ansible/group_vars/*_local.yml
+/ansible/roles/manala.*
+/ansible/roles/.downloads
+!ansible/roles/.gitkeep
+
+!var/.gitkeep
+
 ###> symfony/framework-bundle ###
 /.env.local
 /.env.local.php

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,44 @@ move-test-profiler:
 	@echo "Done : http://resop.vcap.me:7500/_profiler/search?limit=10"
 
 #
+# VM alternative stack commands
+#
+
+setup:
+	vagrant up --no-provision
+	vagrant provision
+
+## Update environment
+update: export ANSIBLE_TAGS = manala.update
+update:
+	vagrant provision
+
+## Update ansible
+update-ansible: export ANSIBLE_TAGS = manala.update
+update-ansible:
+	vagrant provision --provision-with ansible
+
+## Provision environment
+provision: export ANSIBLE_EXTRA_VARS = {"manala":{"update":false}}
+provision:
+	vagrant provision --provision-with app
+
+## Provision nginx
+provision-nginx: export ANSIBLE_TAGS = manala_nginx
+provision-nginx: provision
+
+## Provision php
+provision-php: export ANSIBLE_TAGS = manala_php
+provision-php: provision
+
+install-app:
+	composer install --verbose --no-interaction
+	bin/console cache:clear
+	bin/post-install-dev.sh
+	yarn install --pure-lockfile
+	yarn encore dev
+
+#
 # Help commands
 #
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 
 ## Install
 
+This stack is powered with Docker;
+If you prefer to use a virtual machine, you can follow those steps
+
 ### Requirements
 
 * git
@@ -125,3 +128,53 @@ bin/node-tools yarn encore dev
 webpack-build-dev
 make webpack-watch-dev
 ```
+
+## Alternative Developpement stack based on a VM
+
+If you prefer using a virtual machine using VirtualBox, follow the following procedure. It relies on Ansible roles to provision the VM under the [Manala](http://www.manala.io/) organization.
+
+⚠️ Windows environment is untested for this stack (main concerns are the NFS sharing);
+
+The VM will be provisionned with
+- PHP 7.4
+- PostgreSQL 11.x
+- Nginx
+- Node 10
+- ...
+
+You can find essential configuration inside the (app.yml)[ansible/group_vars/app.yml] file.
+
+### Requirements
+
+- make
+- [VirtualBox 5.2.4+](https://www.virtualbox.org/wiki/Downloads)
+- [Vagrant 2.2.5+](https://www.vagrantup.com/downloads.html)
+- [Vagrant Landrush 1.2.0+](https://github.com/vagrant-landrush/landrush)
+
+### Installation
+
+    $ make setup
+    $ vagrant ssh
+    # uncomment the alternative DATABASE_URL inside the .env file (L39) and comment the default one;
+    $ make install-app
+
+### Boot the VM
+
+    # execute outside the VM
+    $ vagrant up
+
+### Access the VM
+
+    # execute outside the VM
+    $ vagrant ssh
+
+### Shutdown the VM
+
+    # execute outside the VM
+    $ vagrant halt
+
+### Access the project
+
+- Local : http://resop.vcap.vm
+
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,69 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+app = {
+  :name        => 'resop.vcap',
+  :box         => 'manala/app-dev-debian',
+  :box_version => '~> 4.0.5',
+  :box_memory  => 2048
+}
+
+Vagrant.require_version '>= 2.2.5'
+
+Vagrant.configure(2) do |config|
+
+  # Force vagrant to use virtualbox provider
+  config.vm.provider "virtualbox"
+
+  # Ssh
+  config.ssh.username      = 'app'
+  config.ssh.forward_agent = true
+
+  # Vm
+  config.vm.box           = app[:box]
+  config.vm.box_version   = app[:box_version]
+  config.vm.hostname      = app[:name] + '.vm'
+  config.vm.network       'private_network', type: 'dhcp'
+  config.vm.define        'localhost' do |localhost| end
+  config.vm.synced_folder '.', '/srv/app',
+    type: 'nfs',
+    mount_options: ['nolock', 'actimeo=1', 'fsc']
+
+  # Vm - Provider - Virtualbox
+  config.vm.provider :virtualbox do |virtualbox|
+    virtualbox.name   = app[:name]
+    virtualbox.memory = app[:box_memory]
+    virtualbox.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
+    virtualbox.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
+  end
+
+  # Vm - Provision - Dotfiles
+  for dotfile in ['.ssh/config', '.gitconfig', '.gitignore', '.gitignore_global', '.composer/auth.json', '.gnupg/private-keys-v1.d', '.gnupg/pubring.kbx', '.gnupg/pubring.kbx~', '.gnupg/trustdb.gpg']
+    if File.exists?(File.join(Dir.home, dotfile)) then
+      config.vm.provision dotfile, type: 'file', run: 'always' do |file|
+        file.source      = '~/' + dotfile
+        file.destination = '/home/' + config.ssh.username + '/' + dotfile
+      end
+    end
+  end
+
+  # Vm - Provision - Setup
+  for playbook in ['ansible', 'app']
+    config.vm.provision playbook, type: 'ansible_local' do |ansible|
+      ansible.version           = (playbook == 'ansible') ? 'latest' : ''
+      ansible.provisioning_path = '/srv/app/ansible'
+      ansible.playbook          = playbook + '.yml'
+      ansible.inventory_path    = '/etc/ansible/hosts'
+      ansible.tags              = ENV['ANSIBLE_TAGS']
+      ansible.extra_vars        = JSON.parse(ENV['ANSIBLE_EXTRA_VARS'] || '{"manala":{"update":true}}')
+    end
+  end
+
+  # Plugins - Landrush
+  if Vagrant.has_plugin?('landrush')
+    config.landrush.enabled            = true
+    config.landrush.tld                = config.vm.hostname
+    config.landrush.guest_redirect_dns = false
+  end
+
+end

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,4 @@
+[ssh_connection]
+# improve Ansible speed, also fix error on PostgreSQL role while checking binary (fix: https://github.com/plone/ansible.plone_server/issues/86#issuecomment-226457346)
+pipelining=True
+

--- a/ansible/ansible.yml
+++ b/ansible/ansible.yml
@@ -1,0 +1,21 @@
+---
+# App
+- hosts: app
+  vars:
+      manala_ansible_galaxy_roles:
+          - manala.ansible_galaxy
+          - manala.deploy
+          - manala.skeleton
+          - ANXS.postgresql
+  roles:
+      - manala.ansible_galaxy
+
+# Global
+- hosts: all
+  vars:
+      manala_ansible_galaxy_roles_path: '{{ playbook_dir }}/roles'
+      manala_ansible_galaxy_roles:
+          - manala.ansible_galaxy
+          - manala.deploy
+  roles:
+      - manala.ansible_galaxy

--- a/ansible/app.yml
+++ b/ansible/app.yml
@@ -1,0 +1,21 @@
+---
+- hosts: app
+  vars:
+      # App
+      app: '{{ manala_skeleton_options.app }}'
+      # Manala
+      manala_skeleton_name: manala_app_php
+      manala_skeleton_env: '{{ env }}'
+      manala_skeleton_options_hashes:
+          - app_options
+          - app_(\w*)_options
+      manala_skeleton_patterns_hashes:
+          - app_patterns
+          - app_(\w*)_patterns
+  roles:
+      - manala.skeleton
+
+- hosts: app
+  become: yes
+  roles:
+      - ANXS.postgresql

--- a/ansible/group_vars/app.yml
+++ b/ansible/group_vars/app.yml
@@ -1,0 +1,117 @@
+---
+# PostgreSQL (ANXS.postgresql)
+postgresql_version: 11
+postgresql_locale: fr_FR.UTF-8
+postgresql_ctype: fr_FR.UTF-8
+
+postgresql_users:
+    - name: resop
+      pass: postgrespwd
+      encrypted: yes # if password should be encrypted, postgresql >= 10 does only accepts encrypted passwords
+
+# List of user privileges to be applied (optional)
+postgresql_user_privileges:
+    - name: resop # user name
+      role_attr_flags: 'SUPERUSER' # role attribute flags
+
+app_options:
+    apt_preferences:
+        - php@sury_php
+    php_version: '7.4'
+    nodejs: true
+    nodejs_version: '10'
+    mysql: false
+    mongodb: false
+    mariadb: false
+    postgresql: false
+    elasticsearch: false
+    redis: true
+    influxdb: false
+    java: false
+    sqlite: false
+
+    #app:
+    #  env_vars:
+    #    FOO: bar
+
+app_patterns:
+    ############
+    # Timezone #
+    ############
+
+    timezone_default: Europe/Paris
+
+    #########
+    # Files #
+    #########
+
+    files_attributes:
+        - path: '{{ app.dir }}{{ app.dir_release }}/var/log'
+          src: '{{ app.log_dir }}'
+          state: link_directory
+        - path: '{{ app.dir }}{{ app.dir_release }}/var/cache'
+          src: '{{ app.cache_dir }}'
+          state: link_directory
+
+    #######
+    # Php #
+    #######
+
+    php_extensions:
+        # Symfony
+        - intl
+        - curl
+        - mbstring
+        - xml
+        # App
+        - pgsql
+        - gd
+
+    php_configs:
+        - file: app_opcache.ini
+          template: configs/app_opcache.{{ env }}.j2
+        - file: app.ini
+          template: configs/app.{{ env }}.j2
+          config:
+              - date.timezone: Europe/Paris
+
+    php_cli_configs:
+        - file: app_cli.ini
+          config:
+              - memory_limit: -1 # Composer tends to become greedy...
+
+    #########
+    # Nginx #
+    #########
+
+    nginx_configs:
+        # Php fpm
+        - file: app_php_fpm
+          template: configs/app_php_fpm.{{ env }}.j2
+        # Gzip
+        - file: app_gzip
+          template: configs/app_gzip.{{ env }}.j2
+        # App
+        - file: app.conf
+          config:
+              - server:
+                    - listen: 80
+                    - listen: 8000
+                    - listen: 8001
+                    - server_name: '{{ app.host }}'
+                    #- server_name: "*.ngrok.io"
+                    - root: '{{ app.dir }}{{ app.dir_release }}/public'
+                    - access_log: '{{ app.log_dir }}/nginx.access.log'
+                    - error_log: '{{ app.log_dir }}/nginx.error.log'
+                    - include: conf.d/app_gzip
+                    - location /:
+                          - try_files: $uri /index.php$is_args$args
+                    - location ~ ^/index\.php(/|$):
+                          - include: conf.d/app_php_fpm
+                          - set: $APP_ENV dev
+                          - if ( $server_port = 8000 ):
+                                - set: $APP_ENV test
+                          - if ( $server_port = 8001 ):
+                                - set: $APP_ENV prod
+                          - fastcgi_param: APP_ENV $APP_ENV
+                          - internal;

--- a/ansible/group_vars/app_local.yml.sample
+++ b/ansible/group_vars/app_local.yml.sample
@@ -1,0 +1,41 @@
+---
+
+app_local_options:
+
+  #app:
+  #  env_vars:
+  #    XDEBUG_CONFIG:  remote_host={{ ansible_eth1.ipv4.address|regex_replace('^(.*)\.\d+$', '\1') }}.1 idekey=app
+  #    PHP_IDE_CONFIG: serverName={{ ansible_fqdn }}
+
+app_local_patterns:
+
+  #######
+  # Apt #
+  #######
+
+  #apt_repositories:
+  #  - blackfire
+
+  ###################
+  # Php - Blackfire #
+  ###################
+
+  #php_blackfire: false
+
+  #php_blackfire_agent_config:
+  #  - server-id:    ...
+  #  - server-token: ...
+
+  #php_blackfire_client_config:
+  #  - client-id:    ...
+  #  - client-token: ...
+
+  #######
+  # Php #
+  #######
+
+  #php_configs:
+  #  - file: app_local.ini
+  #    config:
+  #      # Symfony ide integration, see: http://symfony.com/doc/current/reference/configuration/framework.html#ide
+  #      - xdebug.file_link_format: "'phpstorm://open?file=%f&line=%l&/srv/app/>/Users/manala/workspace/vendor/app/'"


### PR DESCRIPTION
Hello,

I'm proposing an alternative stack using a virtual machine provisionned with Ansible using open-sourced [manala](https://github.com/manala) roles;

It has very minimal impact to the actual project;

2 directories has been added:
- `var/` -> must be present to the log and cache dir can be symlinked inside the VM
- `ansible/` -> contains the configuration for ansible to provision the VM

1 file has been added:
- `Vagrantfile` which contains the skeleton for the VM;

I don't want to start any fights againt Docker; The stack i'm proposing is working on Unbutu/Debian/MacOS without any performance problematic we often see on MacOS environment with Docker;

I've updated the README to include the requirements;

Summary:

You need to install 4 things:
- make
- [VirtualBox 5.2.4+](https://www.virtualbox.org/wiki/Downloads)
- [Vagrant 2.2.5+](https://www.vagrantup.com/downloads.html)
- [Vagrant Landrush 1.2.0+](https://github.com/vagrant-landrush/landrush)

Then run

```bash
    $ make setup # boot + provision the VM
    $ vagrant ssh # to access the VM
    # uncomment the alternative DATABASE_URL inside the .env file (L39) and comment the default one;
    $ make install-app # provisions the app
```

The codes lies under `/srv/app/` inside the VM.

### Results:

Accessible on : http://resop.vcap.vm/
3 min to boot & provision both the VM and the app

![ResOP_-_Connexion](https://user-images.githubusercontent.com/346010/77929049-808d3a00-72a9-11ea-82c3-daa8895c465d.png)
![Symfony_Profiler](https://user-images.githubusercontent.com/346010/77929148-a0bcf900-72a9-11ea-98a1-75a165f7d484.png)
<img width="1676" alt="app_resop___srv_app" src="https://user-images.githubusercontent.com/346010/77929220-b3373280-72a9-11ea-8b56-13f096535981.png">
