### PR TITLE
Add Behat JavaScript scenarios using Panther

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -3,4 +3,3 @@ KERNEL_CLASS='App\Kernel'
 APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=disabled
 DATABASE_URL=postgresql://resop:postgrespwd@postgres/resop-test?serverVersion=11&charset=utf8
-PANTHER_CHROME_DRIVER_BINARY=/usr/bin/chromedriver

--- a/.env.test
+++ b/.env.test
@@ -2,5 +2,5 @@
 KERNEL_CLASS='App\Kernel'
 APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=disabled
-PANTHER_APP_ENV=panther
 DATABASE_URL=postgresql://resop:postgrespwd@postgres/resop-test?serverVersion=11&charset=utf8
+PANTHER_CHROME_DRIVER_BINARY=/usr/bin/chromedriver

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ env:
     APP_ENV: test
     APP_DEBUG: 0
     DATABASE_SERVER_VERSION: 11 # update service "postgresql" if this value change
+    PANTHER_CHROME_DRIVER_BINARY: /usr/bin/chromedriver
 
 jobs:
     php:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
                   coverage: pcov
                   extensions: ctype, iconv, intl
                   ini-values: date.timezone=UTC, memory_limit=-1, session.gc_probability=0, opcache.enable=1, opcache.enable_cli=1, opcache.memory_consumption=256, opcache.max_accelerated_files=20000, opcache.validate_timestamps=0, realpath_cache_size=4096K, realpath_cache_ttl=600
-                  tools: cs2pr
+                  tools: cs2pr, symfony
 
             - name: Install Node.js
               uses: actions/setup-node@v1
@@ -127,9 +127,15 @@ jobs:
                 flags: unit
                 token: ${{ secrets.CODECOV_TOKEN }}
 
+            - name: Start WebServer in background for Behat tests
+              run: |
+                  symfony serve -d --no-tls --port=8000
+              if: always()
+
             - name: Run Behat tests
               run: |
                   bin/post-install-test.sh
+                  sed -i 's/base_url: .*/base_url: http:\/\/localhost:8000\//' behat.yml.dist
                   vendor/bin/behat --format=progress --out=std --format=junit --out=var/behat
               if: always()
 

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -9,8 +9,18 @@ default:
                 - App\Tests\Behat\UserPlanningContext
                 - Behat\MinkExtension\Context\MinkContext
     extensions:
+        Lctrs\MinkPantherDriver\Extension\PantherExtension: ~
         Behat\MinkExtension:
+            base_url: http://nginx/
+            default_session: symfony
+            javascript_session: panther
             sessions:
+                panther:
+                    panther:
+                        chrome:
+                            arguments:
+                                - "--headless"
+                                - "--no-sandbox"
                 symfony:
                     symfony: ~
         FriendsOfBehat\SymfonyExtension:

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,12 @@
   "license": "GPL-3.0-or-later",
   "name": "crf-devs/resop",
   "description": "ResOp",
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "git@github.com:vincentchalamon/mink-panther-driver.git"
+    }
+  ],
   "require": {
     "php": "^7.4",
     "ext-ctype": "*",
@@ -38,12 +44,13 @@
     "behat/behat": "^3.6",
     "dama/doctrine-test-bundle": "^6.3",
     "escapestudios/symfony2-coding-standard": "^3.11",
-    "friends-of-behat/mink": "^1.8",
+    "friends-of-behat/mink": "1.8.0 as 1.8.1",
     "friends-of-behat/mink-browserkit-driver": "^1.4",
     "friends-of-behat/mink-extension": "^2.4",
     "friends-of-behat/symfony-extension": "^2.1",
     "friendsofphp/php-cs-fixer": "^2.16",
     "hautelook/alice-bundle": "^2.7",
+    "lctrs/mink-panther-driver": "dev-master",
     "mheap/phpunit-github-actions-printer": "^1.2",
     "phpstan/phpstan-doctrine": "^0.12.8",
     "phpstan/phpstan-symfony": "^0.12.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d41f8e3f1683b80fe98714b84529b1fb",
+    "content-hash": "564fb96cfb8941e2ab41f6dc4110da18",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -7943,6 +7943,76 @@
             "time": "2020-03-15T10:07:54+00:00"
         },
         {
+            "name": "lctrs/mink-panther-driver",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vincentchalamon/mink-panther-driver.git",
+                "reference": "e9a2811fcb3ef51d3b42245694d407986eb85098"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vincentchalamon/mink-panther-driver/zipball/e9a2811fcb3ef51d3b42245694d407986eb85098",
+                "reference": "e9a2811fcb3ef51d3b42245694d407986eb85098",
+                "shasum": ""
+            },
+            "require": {
+                "behat/behat": "^3.6.1",
+                "behat/mink": "^1.8.1",
+                "behat/mink-extension": "^2.3.1",
+                "php": "^7.2",
+                "php-webdriver/webdriver": "^1.8.2",
+                "symfony/browser-kit": "^4.4.7 || ^5.0",
+                "symfony/config": "^4.4.7 || ^5.0",
+                "symfony/dependency-injection": "^4.4.7 || ^5.0",
+                "symfony/dom-crawler": "^4.4.7 || ^5.0",
+                "symfony/panther": "^0.7.1",
+                "webmozart/assert": "^1.7.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^7.0.2",
+                "ergebnis/composer-normalize": "^2.3.2",
+                "maglnet/composer-require-checker": "^2.0.0",
+                "matthiasnoback/symfony-config-test": "^4.1.0",
+                "matthiasnoback/symfony-dependency-injection-test": "^3.1.0",
+                "mink/driver-testsuite": "dev-master",
+                "ondram/ci-detector": "^3.3.0",
+                "phpstan/extension-installer": "^1.0.4",
+                "phpstan/phpstan": "^0.12.18",
+                "phpstan/phpstan-deprecation-rules": "^0.12.2",
+                "phpstan/phpstan-phpunit": "^0.12.6",
+                "phpstan/phpstan-strict-rules": "^0.12.2",
+                "phpstan/phpstan-webmozart-assert": "^0.12.3",
+                "phpunit/phpunit": "^7.5.20",
+                "psalm/plugin-phpunit": "^0.10.0",
+                "vimeo/psalm": "^3.10.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Lctrs\\MinkPantherDriver\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Lctrs\\MinkPantherDriver\\Test\\": "test/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "Panther (WebDriver) driver for Mink framework",
+            "support": {
+                "source": "https://github.com/vincentchalamon/mink-panther-driver/tree/master"
+            },
+            "time": "2020-04-23T23:22:33+00:00"
+        },
+        {
             "name": "mheap/phpunit-github-actions-printer",
             "version": "v1.2.0",
             "source": {
@@ -8311,6 +8381,71 @@
                 "diff"
             ],
             "time": "2018-02-15T16:58:55+00:00"
+        },
+        {
+            "name": "php-webdriver/webdriver",
+            "version": "1.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-webdriver/php-webdriver.git",
+                "reference": "3308a70be084d6d7fd1ee5787b4c2e6eb4b70aab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-webdriver/php-webdriver/zipball/3308a70be084d6d7fd1ee5787b4c2e6eb4b70aab",
+                "reference": "3308a70be084d6d7fd1ee5787b4c2e6eb4b70aab",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php": "^5.6 || ~7.0",
+                "symfony/polyfill-mbstring": "^1.12",
+                "symfony/process": "^2.8 || ^3.1 || ^4.0 || ^5.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.0",
+                "jakub-onderka/php-parallel-lint": "^1.0",
+                "php-coveralls/php-coveralls": "^2.0",
+                "php-mock/php-mock-phpunit": "^1.1",
+                "phpunit/phpunit": "^5.7",
+                "sebastian/environment": "^1.3.4 || ^2.0 || ^3.0",
+                "sminnee/phpunit-mock-objects": "^3.4",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/var-dumper": "^3.3 || ^4.0 || ^5.0"
+            },
+            "suggest": {
+                "ext-SimpleXML": "For Firefox profile creation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Facebook\\WebDriver\\": "lib/"
+                },
+                "files": [
+                    "lib/Exception/TimeoutException.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP client for Selenium WebDriver. Previously facebook/webdriver.",
+            "homepage": "https://github.com/php-webdriver/php-webdriver",
+            "keywords": [
+                "Chromedriver",
+                "geckodriver",
+                "php",
+                "selenium",
+                "webdriver"
+            ],
+            "time": "2020-03-04T14:40:12+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -10063,6 +10198,131 @@
             "time": "2020-03-30T11:42:42+00:00"
         },
         {
+            "name": "symfony/http-client",
+            "version": "v5.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "14d386ae55b699ea9a0ddb872fa5f3e35219bba8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/14d386ae55b699ea9a0ddb872fa5f3e35219bba8",
+                "reference": "14d386ae55b699ea9a0ddb872fa5f3e35219bba8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "psr/log": "^1.0",
+                "symfony/http-client-contracts": "^1.1.8|^2",
+                "symfony/polyfill-php73": "^1.11",
+                "symfony/service-contracts": "^1.0|^2"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "1.1"
+            },
+            "require-dev": {
+                "guzzlehttp/promises": "^1.3.1",
+                "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
+                "psr/http-client": "^1.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/http-kernel": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony HttpClient component",
+            "homepage": "https://symfony.com",
+            "time": "2020-03-27T16:56:45+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "378868b61b85c5cac6822d4f84e26999c9f2e881"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/378868b61b85c5cac6822d4f84e26999c9f2e881",
+                "reference": "378868b61b85c5cac6822d4f84e26999c9f2e881",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5"
+            },
+            "suggest": {
+                "symfony/http-client-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-11-26T23:25:11+00:00"
+        },
+        {
             "name": "symfony/maker-bundle",
             "version": "v1.14.6",
             "source": {
@@ -10143,6 +10403,78 @@
                 }
             ],
             "time": "2020-03-04T13:57:29+00:00"
+        },
+        {
+            "name": "symfony/panther",
+            "version": "v0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/panther.git",
+                "reference": "fcc7cfd2168db167daeb21ac5510fe06f2816a83"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/panther/zipball/fcc7cfd2168db167daeb21ac5510fe06f2816a83",
+                "reference": "fcc7cfd2168db167daeb21ac5510fe06f2816a83",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "php-webdriver/webdriver": "^1.8.1",
+                "symfony/browser-kit": "^4.3 || ^5.0",
+                "symfony/dom-crawler": "^4.3 || ^5.0",
+                "symfony/http-client": "^4.3 || ^5.0",
+                "symfony/polyfill-php72": "^1.9",
+                "symfony/process": "^3.4 || ^4.0 || ^5.0"
+            },
+            "conflict": {
+                "symfony/framework-bundle": ">=4.3 <4.3.4"
+            },
+            "require-dev": {
+                "fabpot/goutte": "^3.2.3",
+                "guzzlehttp/guzzle": "^6.3",
+                "symfony/css-selector": "^3.4 || ^4.0 || ^5.0",
+                "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
+                "symfony/mime": "^4.3 || ^5.0",
+                "symfony/phpunit-bridge": "^4.3.3 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Panther\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com",
+                    "homepage": "https://dunglas.fr"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A browser testing and web scraping library for PHP and Symfony.",
+            "homepage": "https://dunglas.fr",
+            "keywords": [
+                "e2e",
+                "scraping",
+                "selenium",
+                "symfony",
+                "testing",
+                "webdriver"
+            ],
+            "time": "2020-02-24T12:05:49+00:00"
         },
         {
             "name": "symfony/phpunit-bridge",
@@ -10613,9 +10945,17 @@
             "time": "2019-06-13T22:48:21+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "1.8.1",
+            "alias_normalized": "1.8.1.0",
+            "version": "1.8.0.0",
+            "package": "friends-of-behat/mink"
+        }
+    ],
     "minimum-stability": "stable",
     "stability-flags": {
+        "lctrs/mink-panther-driver": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": false,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
     environment:
       - APP_ENV=dev
       - APP_DEBUG=1
+      - PANTHER_CHROME_DRIVER_BINARY=/usr/bin/chromedriver
 
   tools:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,6 @@ services:
     environment:
       - APP_ENV=dev
       - APP_DEBUG=1
-      - PANTHER_CHROME_DRIVER_BINARY=/usr/bin/chromedriver
 
   tools:
     build:
@@ -75,6 +74,7 @@ services:
     environment:
       - APP_ENV=dev
       - APP_DEBUG=1
+      - PANTHER_CHROME_DRIVER_BINARY=/usr/bin/chromedriver
     ulimits:
       nofile:
         soft: "65536"

--- a/docker/php-flex/Dockerfile
+++ b/docker/php-flex/Dockerfile
@@ -84,6 +84,12 @@ RUN test -z "$DEBUG_TOOLS" || ( \
         && rm -Rf /tmp/blackfire \
     )
 
+RUN test -z "$DEBUG_TOOLS" || ( \
+        apk add --no-cache \
+            chromium \
+            chromium-chromedriver \
+    )
+
 COPY ./docker/php-flex/files/. /
 
 WORKDIR /srv

--- a/features/user/login.feature
+++ b/features/user/login.feature
@@ -3,6 +3,7 @@ Feature:
     As a user
     I must be able to log in
 
+    @javascript
     Scenario: As anonymous, I cannot access to the homepage
         When I go to the homepage
         Then I should be on "/login"

--- a/symfony.lock
+++ b/symfony.lock
@@ -197,6 +197,9 @@
     "laminas/laminas-zendframework-bridge": {
         "version": "1.0.1"
     },
+    "lctrs/mink-panther-driver": {
+        "version": "0.5.x-dev"
+    },
     "martin-georgiev/postgresql-for-doctrine": {
         "version": "v1.3.0"
     },
@@ -254,6 +257,9 @@
     },
     "php-cs-fixer/diff": {
         "version": "v1.3.0"
+    },
+    "php-webdriver/webdriver": {
+        "version": "1.8.2"
     },
     "phpdocumentor/reflection-common": {
         "version": "2.0.0"
@@ -476,6 +482,12 @@
             "src/Kernel.php"
         ]
     },
+    "symfony/http-client": {
+        "version": "v5.0.7"
+    },
+    "symfony/http-client-contracts": {
+        "version": "v2.0.1"
+    },
     "symfony/http-foundation": {
         "version": "v5.0.1"
     },
@@ -522,6 +534,9 @@
     },
     "symfony/orm-pack": {
         "version": "v1.0.7"
+    },
+    "symfony/panther": {
+        "version": "v0.7.1"
     },
     "symfony/phpunit-bridge": {
         "version": "4.3",


### PR DESCRIPTION
It's even possible to run behat tests on the hosts machine with the following configuration:
```yaml
# behat.yml
default:
    suites:
        default:
            contexts:
                - App\Tests\Behat\CoverageContext
                - App\Tests\Behat\DatabaseContext
                - App\Tests\Behat\FixturesContext
                - App\Tests\Behat\SecurityContext
                - App\Tests\Behat\UserPlanningContext
                - Behat\MinkExtension\Context\MinkContext
    extensions:
        Lctrs\MinkPantherDriver\Extension\PantherExtension: ~
        Behat\MinkExtension:
            base_url: http://resop.vcap.me:7500/
            default_session: symfony
            javascript_session: panther
            sessions:
                panther:
                    panther:
                        chrome:
                            arguments:
                                - "--headless"
                                - "--no-sandbox"
                symfony:
                    symfony: ~
        FriendsOfBehat\SymfonyExtension:
            kernel:
                environment: test
                debug: false
```