### PR TITLE
Serialize User in session

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -30,7 +30,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @UniqueEntity("identificationNumber")
  * @ORM\EntityListeners({AddDependantSkillsEntityListener::class})
  */
-class User implements UserInterface, AvailabilitableInterface, UserSerializableInterface
+class User implements UserInterface, AvailabilitableInterface, UserSerializableInterface, \Serializable
 {
     public const NIVOL_FORMAT = '#^\d+[A-Z]$#';
 
@@ -192,6 +192,31 @@ class User implements UserInterface, AvailabilitableInterface, UserSerializableI
             'id' => $this->id,
             'identificationNumber' => $this->identificationNumber,
         ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize(): string
+    {
+        return serialize([
+            $this->id,
+            $this->identificationNumber,
+            $this->emailAddress,
+            $this->birthday,
+        ]);
+    }
+
+    /**
+     * @param string $serialized
+     */
+    public function unserialize($serialized): void
+    {
+        list(
+            $this->id,
+            $this->identificationNumber,
+            $this->emailAddress,
+            $this->birthday) = unserialize($serialized);
     }
 
     public function getId(): ?int


### PR DESCRIPTION
Closes #408

`serialize` method is called from AbstractToken (symfony/core) to store required User data in session:

https://github.com/symfony/security/blob/59cb5e8798af486a9ecbea9c45774ae8e66f1fe5/Core/Authentication/Token/AbstractToken.php#L160-L163